### PR TITLE
Add handled error logging and refresh visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CoreProtectFix
 
-![CoreProtectFix chat bridge diagram](docs/overview.svg)
+![CoreProtectFix architecture overview](docs/overview.svg)
 
 ## Overview
 CoreProtectFix keeps the CoreProtect database compatible with modern chat pipelines on Paper, Spigot, and hybrid servers such as ArcLight. It replaces the deprecated synchronous chat hooks used by CoreProtect with an asynchronous bridge so that messages recorded in CoreProtect remain accurate even when your server relies on Paper's `AsyncChatEvent`.

--- a/docs/overview.svg
+++ b/docs/overview.svg
@@ -1,44 +1,86 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="480" viewBox="0 0 960 480" role="img" aria-labelledby="title desc">
+  <title id="title">CoreProtectFix architecture overview</title>
+  <desc id="desc">Diagram describing how CoreProtectFix bridges player chat events into the CoreProtect database.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0f172a" />
-      <stop offset="100%" stop-color="#1e293b" />
+      <stop offset="100%" stop-color="#111827" />
     </linearGradient>
+    <linearGradient id="node" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#a855f7" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+    <clipPath id="card">
+      <rect x="0" y="0" width="280" height="200" rx="24" />
+    </clipPath>
     <style>
-      .title { font: 700 42px 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; fill: #f8fafc; }
-      .subtitle { font: 400 22px 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; fill: #cbd5f5; }
-      .label { font: 600 18px 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; fill: #0f172a; }
-      .body { font: 400 16px 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; fill: #0f172a; }
-      .node { fill: #e2e8f0; stroke: #1e293b; stroke-width: 2; rx: 18; }
-      .arrow { fill: none; stroke: #f8fafc; stroke-width: 3; marker-end: url(#arrowhead); }
+      text { font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; }
+      .heading { font-size: 42px; font-weight: 700; fill: #f8fafc; }
+      .tagline { font-size: 22px; fill: #cbd5f5; letter-spacing: 0.04em; }
+      .label { font-size: 20px; font-weight: 600; fill: #0f172a; }
+      .body { font-size: 16px; fill: #0f172a; }
+      .arrow { stroke: #f8fafc; stroke-width: 4; fill: none; marker-end: url(#arrowhead); }
+      .arrow-label { font-size: 16px; fill: #f8fafc; font-weight: 500; }
     </style>
-    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#f8fafc" />
+    <marker id="arrowhead" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto">
+      <polygon points="0 0, 12 4, 0 8" fill="#f8fafc" />
     </marker>
   </defs>
-  <rect width="800" height="400" fill="url(#bg)" rx="32" />
-  <text x="50" y="80" class="title">CoreProtectFix</text>
-  <text x="50" y="120" class="subtitle">Bridge CoreProtect with modern chat pipelines</text>
-  <g transform="translate(40, 150)">
-    <rect class="node" width="200" height="120" />
-    <text x="100" y="40" text-anchor="middle" class="label">Minecraft Server</text>
-    <text x="100" y="72" text-anchor="middle" class="body">Spigot / Paper</text>
-    <text x="100" y="98" text-anchor="middle" class="body">1.20+</text>
+  <rect width="960" height="480" fill="url(#bg)" rx="36" />
+  <g transform="translate(60 72)">
+    <text class="heading">CoreProtectFix</text>
+    <text class="tagline" y="44">Modern chat bridge for the CoreProtect ecosystem</text>
   </g>
-  <g transform="translate(300, 150)">
-    <rect class="node" width="200" height="120" />
-    <text x="100" y="40" text-anchor="middle" class="label">CoreProtectFix</text>
-    <text x="100" y="72" text-anchor="middle" class="body">Async chat bridge</text>
-    <text x="100" y="98" text-anchor="middle" class="body">Event compatibility</text>
+  <g transform="translate(70 150)">
+    <g clip-path="url(#card)">
+      <rect width="280" height="200" fill="#e2e8f0" />
+      <rect width="280" height="88" fill="url(#node)" />
+      <g transform="translate(140 50)" text-anchor="middle">
+        <text fill="#0f172a" font-size="34" font-weight="700">Players</text>
+      </g>
+      <g transform="translate(140 124)" text-anchor="middle">
+        <text class="label">Minecraft Server</text>
+        <text class="body" y="28">Paper · Spigot · ArcLight</text>
+      </g>
+    </g>
   </g>
-  <g transform="translate(560, 150)">
-    <rect class="node" width="200" height="120" />
-    <text x="100" y="40" text-anchor="middle" class="label">CoreProtect</text>
-    <text x="100" y="72" text-anchor="middle" class="body">Logging database</text>
-    <text x="100" y="98" text-anchor="middle" class="body">Rollback &amp; audit</text>
+  <g transform="translate(340 150)">
+    <g clip-path="url(#card)">
+      <rect width="280" height="200" fill="#ede9fe" />
+      <rect width="280" height="88" fill="url(#accent)" />
+      <g transform="translate(140 52)" text-anchor="middle">
+        <text fill="#0f172a" font-size="32" font-weight="700">CoreProtectFix</text>
+      </g>
+      <g transform="translate(140 124)" text-anchor="middle">
+        <text class="label">Async chat bridge</text>
+        <text class="body" y="26">Wraps Paper and legacy APIs</text>
+        <text class="body" y="48">Normalizes payloads for CoreProtect</text>
+      </g>
+    </g>
   </g>
-  <path class="arrow" d="M240 210 H300" />
-  <path class="arrow" d="M500 210 H560" />
-  <text x="270" y="196" text-anchor="middle" class="body" fill="#f8fafc">Async Chat Events</text>
-  <text x="530" y="196" text-anchor="middle" class="body" fill="#f8fafc">Bridge</text>
+  <g transform="translate(610 150)">
+    <g clip-path="url(#card)">
+      <rect width="280" height="200" fill="#f8fafc" />
+      <rect width="280" height="88" fill="#38bdf8" />
+      <g transform="translate(140 52)" text-anchor="middle">
+        <text fill="#0f172a" font-size="32" font-weight="700">CoreProtect</text>
+      </g>
+      <g transform="translate(140 124)" text-anchor="middle">
+        <text class="label">Database &amp; rollback</text>
+        <text class="body" y="26">Receives sanitized chat events</text>
+        <text class="body" y="48">Keeps audit trail intact</text>
+      </g>
+    </g>
+  </g>
+  <path class="arrow" d="M280 240 H340"/>
+  <path class="arrow" d="M550 240 H610"/>
+  <text class="arrow-label" x="310" y="220" text-anchor="middle">Async chat payload</text>
+  <text class="arrow-label" x="580" y="220" text-anchor="middle">Normalized event</text>
+  <g transform="translate(480 372)" text-anchor="middle">
+    <text class="arrow-label">Seamless auditing without patching CoreProtect</text>
+  </g>
 </svg>

--- a/src/main/java/com/ssilensio/coreprotectfix/ChatBridge.java
+++ b/src/main/java/com/ssilensio/coreprotectfix/ChatBridge.java
@@ -71,6 +71,9 @@ final class ChatBridge implements Listener {
                 plugin.getLogger().warning("[CP Bridge] CoreProtect API call failed: "
                         + ex.getClass().getSimpleName() + ": " + ex.getMessage());
             }
+            if (plugin instanceof CoreProtectFixPlugin coreProtectFixPlugin) {
+                coreProtectFixPlugin.logHandledError("ChatBridge:onChat", ex);
+            }
         }
     }
 }

--- a/src/main/java/com/ssilensio/coreprotectfix/CoreProtectFixPlugin.java
+++ b/src/main/java/com/ssilensio/coreprotectfix/CoreProtectFixPlugin.java
@@ -2,11 +2,42 @@ package com.ssilensio.coreprotectfix;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.logging.Level;
+
 public final class CoreProtectFixPlugin extends JavaPlugin {
+
+    private Path handledErrorLog;
+    private final Object logLock = new Object();
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
+        initializeHandledErrorLog();
+        printBanner();
 
         // 1) Villager/ZombieVillager profession shim
         if (getConfig().getBoolean("affect-villagers", true) ||
@@ -33,5 +64,161 @@ public final class CoreProtectFixPlugin extends JavaPlugin {
     /* Utility */
     public boolean debug() {
         return getConfig().getBoolean("debug", false);
+    }
+
+    void logHandledError(String source, Throwable error) {
+        if (handledErrorLog == null || error == null) {
+            return;
+        }
+
+        synchronized (logLock) {
+            try {
+                Document document = loadLogDocument();
+                Element root = document.getDocumentElement();
+
+                Element entry = document.createElement("error");
+                entry.setAttribute("timestamp", Instant.now().toString());
+
+                Element sourceElement = document.createElement("source");
+                sourceElement.appendChild(document.createTextNode(source));
+                entry.appendChild(sourceElement);
+
+                Element typeElement = document.createElement("type");
+                typeElement.appendChild(document.createTextNode(error.getClass().getName()));
+                entry.appendChild(typeElement);
+
+                Element messageElement = document.createElement("message");
+                messageElement.appendChild(document.createTextNode(
+                        error.getMessage() == null ? "" : error.getMessage()));
+                entry.appendChild(messageElement);
+
+                StringWriter stackWriter = new StringWriter();
+                stackWriter.write(error.toString());
+                stackWriter.write(System.lineSeparator());
+                for (StackTraceElement element : error.getStackTrace()) {
+                    stackWriter.write("    at ");
+                    stackWriter.write(element.toString());
+                    stackWriter.write(System.lineSeparator());
+                }
+                Throwable cause = error.getCause();
+                while (cause != null) {
+                    stackWriter.write("Caused by: ");
+                    stackWriter.write(cause.toString());
+                    stackWriter.write(System.lineSeparator());
+                    for (StackTraceElement element : cause.getStackTrace()) {
+                        stackWriter.write("    at ");
+                        stackWriter.write(element.toString());
+                        stackWriter.write(System.lineSeparator());
+                    }
+                    cause = cause.getCause();
+                }
+
+                Element stackElement = document.createElement("stacktrace");
+                stackElement.appendChild(document.createCDATASection(stackWriter.toString()));
+                entry.appendChild(stackElement);
+
+                root.appendChild(entry);
+                saveLogDocument(document);
+            } catch (IOException | ParserConfigurationException | SAXException | TransformerException e) {
+                getLogger().log(Level.WARNING, "[CoreProtectFix] Failed to append handled error log entry.", e);
+            }
+        }
+    }
+
+    private void initializeHandledErrorLog() {
+        try {
+            Files.createDirectories(getDataFolder().toPath());
+            handledErrorLog = getDataFolder().toPath().resolve("handled-errors.xml");
+
+            DocumentBuilderFactory factory = secureFactory();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+
+            if (Files.exists(handledErrorLog)) {
+                try (InputStream in = Files.newInputStream(handledErrorLog)) {
+                    builder.parse(in);
+                    return; // Existing log is valid
+                } catch (SAXException ex) {
+                    // Fall through to recreate the document
+                }
+            }
+
+            Document document = builder.newDocument();
+            Element root = document.createElement("errors");
+            document.appendChild(root);
+            saveLogDocument(document);
+        } catch (IOException | ParserConfigurationException | TransformerException e) {
+            handledErrorLog = null;
+            getLogger().log(Level.WARNING, "[CoreProtectFix] Failed to initialize handled error log.", e);
+        }
+    }
+
+    private Document loadLogDocument() throws ParserConfigurationException, IOException, SAXException {
+        DocumentBuilderFactory factory = secureFactory();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        if (Files.notExists(handledErrorLog)) {
+            Document document = builder.newDocument();
+            Element root = document.createElement("errors");
+            document.appendChild(root);
+            return document;
+        }
+
+        try (InputStream inputStream = Files.newInputStream(handledErrorLog)) {
+            Document document = builder.parse(inputStream);
+            document.getDocumentElement().normalize();
+            return document;
+        }
+    }
+
+    private void saveLogDocument(Document document) throws TransformerException, IOException {
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        try {
+            transformerFactory.setAttribute("indent-number", 2);
+        } catch (RuntimeException ignored) {
+            // Some TransformerFactory implementations do not support this attribute.
+        }
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name());
+
+        try (Writer writer = Files.newBufferedWriter(handledErrorLog,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE)) {
+            transformer.transform(new DOMSource(document), new StreamResult(writer));
+        }
+    }
+
+    private DocumentBuilderFactory secureFactory() {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException ignored) {
+            // Older JVMs may not support this feature; continue with defaults.
+        }
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (RuntimeException ignored) {
+            // Attributes are optional; ignore if unsupported.
+        }
+        return factory;
+    }
+
+    private void printBanner() {
+        String[] bannerLines = new String[] {
+                "\u001B[36m   ██████╗  ██████╗ ██████╗ ███████╗██████╗ ██████╗ ███████╗████████╗\u001B[0m",
+                "\u001B[36m   ██╔══██╗██╔════╝██╔═══██╗██╔════╝██╔══██╗██╔══██╗██╔════╝╚══██╔══╝\u001B[0m",
+                "\u001B[36m   ██████╔╝██║     ██║   ██║█████╗  ██████╔╝██████╔╝█████╗     ██║   \u001B[0m",
+                "\u001B[36m   ██╔══██╗██║     ██║   ██║██╔══╝  ██╔══██╗██╔══██╗██╔══╝     ██║   \u001B[0m",
+                "\u001B[36m   ██║  ██║╚██████╗╚██████╔╝███████╗██║  ██║██║  ██║███████╗   ██║   \u001B[0m",
+                "\u001B[36m   ╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝   ╚═╝   \u001B[0m",
+                "\u001B[35m      CoreProtectFix — bridging CoreProtect with modern chat APIs\u001B[0m"
+        };
+
+        for (String line : bannerLines) {
+            getLogger().info(line);
+        }
     }
 }

--- a/src/main/java/com/ssilensio/coreprotectfix/FixVillagerProfessionShim.java
+++ b/src/main/java/com/ssilensio/coreprotectfix/FixVillagerProfessionShim.java
@@ -31,6 +31,7 @@ final class FixVillagerProfessionShim implements Listener {
                 plugin.getLogger().warning("[VillagerShim] Failed to neutralize profession: "
                         + ex.getClass().getSimpleName() + ": " + ex.getMessage());
             }
+            plugin.logHandledError("VillagerShim:onDeath", ex);
         }
     }
 
@@ -40,7 +41,9 @@ final class FixVillagerProfessionShim implements Listener {
                 villager.setProfession(p);
                 if (plugin.debug()) plugin.getLogger().info("[VillagerShim] Villager profession set to " + p);
             }
-        } catch (Throwable ignored) { }
+        } catch (Throwable ex) {
+            plugin.logHandledError("VillagerShim:safeSetVillagerProfession", ex);
+        }
     }
 
     private void safeSetZombieVillagerProfession(ZombieVillager zv, Villager.Profession p) {
@@ -49,6 +52,8 @@ final class FixVillagerProfessionShim implements Listener {
                 zv.setVillagerProfession(p);
                 if (plugin.debug()) plugin.getLogger().info("[VillagerShim] ZombieVillager profession set to " + p);
             }
-        } catch (Throwable ignored) { }
+        } catch (Throwable ex) {
+            plugin.logHandledError("VillagerShim:safeSetZombieVillagerProfession", ex);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add an ANSI startup banner and initialize an XML log file for handled errors
- record villager shim and chat bridge exceptions into the new log
- refresh the README hero image with an updated architecture diagram

## Testing
- mvn -DskipTests package *(fails: missing org.spigotmc:spigot-api:jar:1.20.1-R0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68de44a667448320a457522750009c5f